### PR TITLE
add map

### DIFF
--- a/doc/cpp_library.md
+++ b/doc/cpp_library.md
@@ -1,0 +1,7 @@
+# C++ のライブラリを学ぶ
+
+| 用途 | python | C++ |
+| ---- | ------ | ---- |
+| ファイルシステム | pathlib | std::filesystem |
+| list | list | `std::vector<std::string>` |
+| dict | {}   | `std::map<std::string, int>` |

--- a/ex_map.cpp
+++ b/ex_map.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <map>
+#include <string>
+
+int main() {
+    // std::mapを使用して元素記号から元素名へのマッピングを作成します。
+    std::map<std::string, std::string> elementMap;
+    elementMap["H"] = "Hydrogen";
+    elementMap["O"] = "Oxygen";
+    elementMap["N"] = "Nitrogen";
+    elementMap["C"] = "Carbon";
+
+    // 元素記号を入力して、対応する元素名を取得します。
+    std::string symbol;
+    std::cout << "Enter an element symbol (H, O, N, C): ";
+    std::cin >> symbol;
+
+    // マップを使用して元素名を取得し、表示します。
+    if (elementMap.find(symbol) != elementMap.end()) {
+        std::cout << "Element Name: " << elementMap[symbol] << std::endl;
+    } else {
+        std::cout << "Element not found." << std::endl;
+    }
+
+    return 0;
+}

--- a/ex_map2.cpp
+++ b/ex_map2.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <map>
+#include <string>
+
+int main() {
+    // std::mapを使用して元素記号から元素名へのマッピングを作成します。
+    std::map<std::string, std::string> elementMap;
+    elementMap["H"] = "Hydrogen";
+    elementMap["O"] = "Oxygen";
+    elementMap["N"] = "Nitrogen";
+    elementMap["C"] = "Carbon";
+
+    // マップをループで回してキー(symbol)と対応する値(元素名)を表示します。
+    for (const auto& pair : elementMap) {
+        const std::string& symbol = pair.first;
+        const std::string& elementName = pair.second;
+
+        std::cout << "Symbol: " << symbol << ", Element Name: " << elementName << std::endl;
+    }
+
+    return 0;
+}

--- a/fs.cpp
+++ b/fs.cpp
@@ -3,21 +3,23 @@
 #include <vector>
 #include <filesystem>
 
-// -std=c++17
-//
-
 namespace fs = std::filesystem;
 
-void ExploreDirectory(const fs::path& directory) {
+std::vector<std::string> ExploreDirectory(const fs::path& directory) {
+    std::vector<std::string> fileNames;
+
     for (const auto& entry : fs::directory_iterator(directory)) {
         if (fs::is_directory(entry)) {
             // ディレクトリの場合、再帰的に探索
-            ExploreDirectory(entry.path());
+            auto subDirectoryFiles = ExploreDirectory(entry.path());
+            fileNames.insert(fileNames.end(), subDirectoryFiles.begin(), subDirectoryFiles.end());
         } else if (fs::is_regular_file(entry) && entry.path().extension() == ".cpp") {
-            // ファイルの場合、ファイル名を表示
-            std::cout << "File: " << entry.path().string() << std::endl;
+            // 拡張子が ".cpp" のファイルを追加
+            fileNames.push_back(entry.path().string());
         }
     }
+
+    return fileNames;
 }
 
 int main() {
@@ -25,8 +27,13 @@ int main() {
         // カレントディレクトリを取得
         fs::path currentDir = fs::current_path();
 
-        // ディレクトリを探索
-        ExploreDirectory(currentDir);
+        // ディレクトリを探索してファイル名のリストを取得
+        std::vector<std::string> fileNames = ExploreDirectory(currentDir);
+
+        // ファイル名を表示
+        for (const auto& fileName : fileNames) {
+            std::cout << "File: " << fileName << std::endl;
+        }
     } catch (const std::exception& ex) {
         std::cerr << "エラー: " << ex.what() << std::endl;
     }


### PR DESCRIPTION
# what
std::map を使う例題を追加。
std::filesystem を使う例題を、std::vector<std::string>型を返す例題に改変した。
